### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
 
 ## Dependencies
 
-- `bash`, `curl`, `tar`: generic POSIX utilities.
+- `bash`, `curl`, `tar`: generic POSIX utilities,
+- a JDK 11+ for Quarkus (you can install one using [asdf-java](https://github.com/halcyon/asdf-java)).
 
 ## Install
 


### PR DESCRIPTION
A JDK 11+ is required in order to use Quarkus CLI.