### PR TITLE
Use GitHub API to list all versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,18 @@
 - [Dependencies](#dependencies)
 - [Install](#install)
 - [Completion](#completion)
-- [Implementation notes](#implementation-notes)
+- [Notes](#notes)
 - [Contributing](#contributing)
 - [License](#license)
 
 ## Dependencies
 
+Install dependencies :
 - `bash`, `curl`, `tar`: generic POSIX utilities,
-- a JDK 11+ for Quarkus (you can install one using [asdf-java](https://github.com/halcyon/asdf-java)).
+- [`jq`](https://stedolan.github.io/jq/) : a lightweight and flexible command-line JSON processor.
+
+Quarkus dependencies :
+- JDK 11 (or greater) : you can install one using [asdf-java](https://github.com/halcyon/asdf-java).
 
 ## Install
 
@@ -52,13 +56,13 @@ Check [asdf](https://github.com/asdf-vm/asdf) readme for more instructions on ho
 
 Quarkus command completion is not managed by this plugin. Check the [Quarkus CLI documentation](https://quarkus.io/guides/cli-tooling#shell-autocomplete-and-aliases) for instructions on how to configure it.
 
-## Implementation notes
+## Notes
 
-This plugin downloads Quarkus CLI from [GitHub releases of the Quarkus project](https://github.com/quarkusio/quarkus/releases).
+This plugin downloads Quarkus CLI from [GitHub releases of the Quarkus project](https://github.com/quarkusio/quarkus/releases) and only releases containing a Quarkus CLI `tar.gz` file are considered.
 
-Quarkus CLI releases are found using the [Quarkus project's tags](https://github.com/quarkusio/quarkus/tags) from version 2.6.2. Before this version Quarkus CLI did not exist or was not published on GitHub releases.
+This plugin uses the GitHub API to retrieve Quarkus CLI releases. If you reach the limit you may consider declaring a `GITHUB_API_TOKEN` environment variables [with a personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to increase it. Take a look at [the GitHub documentation](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) for more information about GitHub API rate limiting.
 
-Note that Quarkus CLI releases are meant to be backward compatible. [You are encouraged to always use the latest release](https://groups.google.com/g/quarkus-dev/c/R_CZ7My4Rxc/m/WuxnSTjGBQAJ).
+Quarkus CLI releases are meant to be backward compatible. [You are encouraged to always use the latest release](https://groups.google.com/g/quarkus-dev/c/R_CZ7My4Rxc/m/WuxnSTjGBQAJ).
 
 ## Contributing
 

--- a/contributing.md
+++ b/contributing.md
@@ -3,9 +3,7 @@
 Testing Locally:
 
 ```shell
-asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
-
-#
+# asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 asdf plugin test quarkus https://github.com/marcwrobel/asdf-quarkus.git "quarkus --help"
 ```
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -26,14 +26,13 @@ sort_versions() {
 list_all_versions() {
   local url="https://api.github.com/repos/$GH_REPO/releases"
   local jq_filter='.[] | select (.prerelease == false) | select (any(.assets[].name; . | startswith("quarkus-cli"))) | .tag_name'
-  curl "${curl_opts[@]}" "$url" | jq -r "$jq_filter"
+  curl "${curl_opts[@]}" "$url" | jq -r "$jq_filter" || fail "Could not fetch versions from $url"
 }
 
 download_release() {
-  local version filename url
-  version="$1"
-  filename="$2"
-  url="https://github.com/$GH_REPO/releases/download/${version}/$TOOL_NAME-cli-${version}.tar.gz"
+  local version="$1"
+  local filename="$2"
+  local url="https://github.com/$GH_REPO/releases/download/${version}/$TOOL_NAME-cli-${version}.tar.gz"
 
   echo "* Downloading $TOOL_NAME release $version..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
@@ -52,8 +51,7 @@ install_version() {
     mkdir -p "$install_path"
     cp -r "$ASDF_DOWNLOAD_PATH"/* "$install_path"
 
-    local tool_cmd
-    tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
+    local tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
     test -x "$install_path/bin/$tool_cmd" || fail "Expected $install_path/bin/$tool_cmd to be executable."
 
     echo "$TOOL_NAME $version installation was successful!"


### PR DESCRIPTION
Using git tags for this task is problematic :

- there is no way to know if, for a given tag, the corresponding quarkus-cli distribution exists,
- sometimes tags are created before the release is done (e.g. 2.10.0.Final).