### PR TITLE
Update Java version in workflow.yml from 11 to 17

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 11
+          java-version: 17
 
       - uses: asdf-vm/actions/plugin-test@v3
         with:


### PR DESCRIPTION
Quarkus has now a Java 17 baseline, see https://quarkus.io/blog/quarkus-3-7-released/.